### PR TITLE
Documentation improvements

### DIFF
--- a/mldatafind/find.py
+++ b/mldatafind/find.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections import OrderedDict
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, wait
 from dataclasses import dataclass
@@ -7,11 +6,6 @@ from pathlib import Path
 from typing import Iterator, List, Optional, Sequence, Tuple
 
 from mldatafind.io import fetch_timeseries, read_timeseries
-
-DEFAULT_SEGMENT_SERVER = os.getenv(
-    "DEFAULT_SEGMENT_SERVER", "https://segments.ligo.org"
-)
-
 
 BITS_PER_BYTE = 8
 MEMORY_LIMIT = 5
@@ -157,7 +151,6 @@ def find_data(
     array_like: bool = False,
     n_workers: int = 4,
     thread: bool = True,
-    segment_url: str = DEFAULT_SEGMENT_SERVER,
 ) -> Iterator:
 
     """

--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 from gwpy.timeseries import TimeSeries, TimeSeriesDict
@@ -136,11 +136,10 @@ def ts_dict_to_array(ts_dict: TimeSeriesDict):
     All channels in TimeSeriesDict are expected
     to have the same sample rate, t0, and length
 
-
     Args:
         ts_dict: TimeSeriesDict
 
-    returns array of channels, array of times
+    Returns array of channels, array of times
     """
 
     _validate_ts_dict(ts_dict)
@@ -159,22 +158,32 @@ def read_timeseries(
     channels: List[str],
     t0: Optional[float] = None,
     tf: Optional[float] = None,
-    array_like: bool = True,
-) -> np.ndarray:
+    array_like: bool = False,
+) -> Union[TimeSeriesDict, Tuple[np.ndarray, np.ndarray]]:
     """
+    Read multiple channel timeseries from hdf5 or gwf
+    files into a TimeSeriesDict, or, if `array_like` is True,
+    a tuple of numpy arrays where the first element is an array
+    of the channels, and the second element is an array of corresponding times.
     Thin wrapper around TimeSeriesDict.read
 
-    Read multiple channel timeseries into an array or TimeSeriesDict.
-
     Args:
-        path: path to h5 file to read
-        datasets: channel name to read
+        path:
+            File path, Iterable of file paths,
+            or directory containing file paths to read
+        channels:
+            Channel names to read
         t0:
+            Start gpstime to read.
+            If not passed will begin reading from earliest found time
         tf:
+            Stop gpstime to read.
+            If not passed will read until latest found time
         array_like:
-            If true return in array like format. Otherwise,
-            return gwpy.TimeSeriesDict
-    Returns array of datasets
+            Return in array like format.
+            Otherwise, return gwpy.TimeSeriesDict
+
+    Returns gwpy.TimeSeriesDict or Tuple of np.ndarrays
     """
 
     # downselect to files containing requested range
@@ -200,12 +209,29 @@ def fetch_timeseries(
     tf: float,
     nproc: int = 1,
     array_like: bool = True,
-):
+) -> Union[TimeSeriesDict, Tuple[np.ndarray, np.ndarray]]:
     """
+    Fetch multiple channel timeseries from nds2 and store TimeSeriesDict,
+    or, if `array_lke` is True, a tuple of numpy arrays
+    where the first element is an array of the channel data,
+    and the second element an array of corresponding times.
     Thin wrapper around TimeSeriesDict.get
 
-    Fetch multiple channel timeseries from nds2 and store in
-    array or TimeSeriesDict
+    Args:
+        channels:
+            Channel names to fetch
+        t0:
+            Start gpstime to read.
+            If not passed will begin reading from earliest found time
+        tf:
+            Stop gpstime to read.
+            If not passed will read until latest found time
+        nproc:
+            Number of concurrent processes to use with TimeSeriesDict.get
+        array_like:
+            Return in array like format. Otherwise, return gwpy.TimeSeriesDict
+
+    Returns gwpy.TimeSeriesDict or Tuple of np.ndarrays
     """
     ts_dict = TimeSeriesDict.get(
         channels, start=t0, end=tf, nproc=nproc, verbose=True
@@ -218,49 +244,50 @@ def fetch_timeseries(
     return data, times
 
 
-# TODO: Should we just pass times array
-# instead of t0 + sample_rate
-# for consistency with return value of read_timeseries ?
+def _intify(x: float):
+    return int(x) if int(x) == x else x
+
+
 def write_timeseries(
     write_dir: Path,
-    t0: float,
-    sample_rate: float,
+    times: np.ndarray,
     prefix: str,
     file_format: str = "hdf5",
     **datasets,
-):
+) -> Path:
     """
     Write multi-channel timeseries to specified format (either gwf or h5).
-
-    This function is a thin wrapper around gwpy.TimeSeriesDict.write
+    Thin wrapper around gwpy.TimeSeriesDict.write
 
     Args:
-        write_dir: Directory to store files
-        t0: gps start time of datasets
-        sample_rate: sample rate shared by all datasets
-        prefix: prefix used for file name
+        write_dir:
+            Path to directory to write files
+        times:
+            gpstimes corresponding to datasets
+        prefix:
+            Prefix used for file name
 
     Returns path to output file
     """
 
     if file_format not in ["hdf5", "gwf"]:
         raise ValueError(f"Writing to {format} format is not supported")
+
     # ensure all channels have same length
     n_samples = [len(dataset) for dataset in datasets.values()]
 
     if len(set(n_samples)) != 1:
         raise ValueError("Channels must all be of the same length")
 
-    n_samples = n_samples[0]
+    length = times[-1] - times[0] + times[1] - times[0]
+    t0 = times[0]
 
-    # infer duration in time of datasets
-    length = n_samples / sample_rate
-
-    length = int(length) if int(length) == length else length
-    t0 = int(t0) if int(t0) == t0 else t0
+    t0 = _intify(t0)
+    length = _intify(length)
 
     # package data into TimeSeriesDict
     ts_dict = TimeSeriesDict()
+    sample_rate = 1 / (times[1] - times[0])
     for channel, dataset in datasets.items():
         ts_dict[channel] = TimeSeries(dataset, dt=1 / sample_rate, t0=t0)
 

--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -208,7 +208,7 @@ def fetch_timeseries(
     t0: float,
     tf: float,
     nproc: int = 1,
-    array_like: bool = True,
+    array_like: bool = False,
 ) -> Union[TimeSeriesDict, Tuple[np.ndarray, np.ndarray]]:
     """
     Fetch multiple channel timeseries from nds2 and store TimeSeriesDict,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -23,7 +23,9 @@ def check_file_contents(fname, sample_rate, t0, file_length, **datasets):
             ts.times.value == np.arange(t0, t0 + file_length, 1 / sample_rate)
         ).all()
 
-    data, times = io.read_timeseries(fname, list(datasets.keys()))
+    data, times = io.read_timeseries(
+        fname, list(datasets.keys()), array_like=True
+    )
     assert (times == np.arange(t0, t0 + file_length, 1 / sample_rate)).all()
     for i, (_, value) in enumerate(datasets.items()):
         assert (data[i] == value).all()
@@ -146,6 +148,8 @@ def test_write_timeseries(
 ):
 
     datasets = {}
+    times = np.arange(t0, t0 + file_length, 1 / sample_rate)
+
     for channel_name in channel_names:
         datasets[channel_name] = np.arange(
             0,
@@ -153,7 +157,7 @@ def test_write_timeseries(
         )
 
     fname = io.write_timeseries(
-        write_dir, t0, sample_rate, prefix, file_format, **datasets
+        write_dir, times, prefix, file_format, **datasets
     )
 
     assert fname.name == f"{prefix}-{int(t0)}-{int(file_length)}.hdf5"
@@ -169,7 +173,9 @@ def test_read_timeseries(
 
     # first try reading when passing
     # the write directory
-    data, times = io.read_timeseries(write_dir, channel_names, t0, t0 + 1000)
+    data, times = io.read_timeseries(
+        write_dir, channel_names, t0, t0 + 1000, array_like=True
+    )
 
     assert (times == np.arange(t0, t0 + 1000, 1 / sample_rate)).all()
     assert data.shape == (len(channel_names), sample_rate * 1000)
@@ -178,7 +184,9 @@ def test_read_timeseries(
 
     # now try reading when passing
     # list of files
-    data, times = io.read_timeseries(file_names, channel_names, t0, t0 + 1000)
+    data, times = io.read_timeseries(
+        file_names, channel_names, t0, t0 + 1000, array_like=True
+    )
 
     for i, dataset in enumerate(data):
         assert (dataset == np.arange(0, 1000 * sample_rate) * (i + 1)).all()
@@ -189,7 +197,7 @@ def test_read_timeseries(
     # now try reading when passing
     # single file
     data, times = io.read_timeseries(
-        file_names[0], channel_names, t0, t0 + file_length - 1
+        file_names[0], channel_names, t0, t0 + file_length - 1, array_like=True
     )
 
     for i, dataset in enumerate(data):


### PR DESCRIPTION
1. Cleans up documentation of `mldatafind.io` functions
2. `write_timeseries` now takes `times` array instead of `sample_rate` and `t0`
