### PR TITLE
getting rid of ts dict validation when not array like

### DIFF
--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -196,7 +196,6 @@ def read_timeseries(
     ts_dict = TimeSeriesDict.read(paths, channels, start=t0, end=tf)
 
     if not array_like:
-        _validate_ts_dict(ts_dict)
         return ts_dict
 
     data, times = ts_dict_to_array(ts_dict)
@@ -237,7 +236,6 @@ def fetch_timeseries(
         channels, start=t0, end=tf, nproc=nproc, verbose=True
     )
     if not array_like:
-        _validate_ts_dict(ts_dict)
         return ts_dict
 
     data, times = ts_dict_to_array(ts_dict)


### PR DESCRIPTION
When fetching witness channels, their sample rate will be different than the strain data's. Enforcing the `validate_ts_dict` check when `array_like=False` precludes this use case entirely. In principle this is less of a problem when reading, since you can always write things with the same sample rate (and I think the `write_timeseries` API even enforces that, correct?), but I guess my thinking is if people want `TimeSeriesDict`s, and `TimeSeriesDict`s can handle this, then give them what they're asking for and trust they know what they want to do with the channels downstream.