### PR TITLE
adding Docker build materials

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+.git
+**/__pycache__/

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -25,3 +29,36 @@ jobs:
     -
       name: run tests
       run: pinto run pytest
+
+  # build the container and push it to this
+  # repo's container registry
+  push_image:
+    name: Push docker image
+    needs: test  # only run if tests pass
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}  # only run on push to main
+    steps:
+      - 
+        name: Check out the repo
+        uses: actions/checkout@v2
+      - 
+        name: Log in to container registry
+        uses: docker/login-action@master
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@master
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM continuumio/miniconda3:4.12.0
+
+# set up some conda stuff
+SHELL ["/bin/bash", "-c"]
+ENV CONDA_INIT=$CONDA_PREFIX/etc/profile.d/conda.sh
+
+# install kinit utility
+RUN apt-get update \
+        \
+        && apt-get install -y --no-install-recommends \
+            wget \
+            build-essential \
+            bison \
+        \
+        && wget http://web.mit.edu/kerberos/dist/krb5/1.20/krb5-1.20.1.tar.gz \
+        \
+        && tar -xzf krb5-1.20.1.tar.gz \
+        \
+        && cd krb5-1.20.1/src \
+        \
+        && ./configure \
+        \
+        && make \
+        \
+        && make install \
+        \
+        && rm -rf /var/lib/apt/lists/*
+
+# install mldatafind
+COPY . /opt/mldatafind
+RUN python -m pip install poetry==1.2.0b3 \
+        \
+        && conda env create -f /opt/mldatafind/environment.yaml \
+        \
+        && source $CONDA_INIT \
+        \
+        && conda activate mldatafind \
+        \
+        && python -m pip install /opt/mldatafind \
+        \
+        && sed -i 's/conda activate base/conda activate mldatafind/g' ~/.bashrc
+
+# required environment variables with their default locations
+ENV LIGO_USERNAME=albert.einstein \
+    KRB5_KTNAME=/root/.kerberos/ligo.org.keytab \
+    X509_USER_PROXY=/root/cilogon_cert/CERT_KEY.pem
+VOLUME /root/.kerberos /root/cilogon_cert

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,17 @@ FROM continuumio/miniconda3:4.12.0
 
 # set up some conda stuff
 SHELL ["/bin/bash", "-c"]
-ENV CONDA_INIT=$CONDA_PREFIX/etc/profile.d/conda.sh
+ENV CONDA_INIT=$CONDA_PREFIX/etc/profile.d/conda.sh \
+    DEBIAN_FRONTEND=noninteractive
 
-# install kinit utility
+# install kerberos executables
 RUN apt-get update \
         \
+        && printf '[libdefaults]\n  default_realm = LIGO.ORG\n' > /etc/krb5.confg \
+        \
         && apt-get install -y --no-install-recommends \
-            wget \
+            krb5-user \
             build-essential \
-            bison \
-        \
-        && wget http://web.mit.edu/kerberos/dist/krb5/1.20/krb5-1.20.1.tar.gz \
-        \
-        && tar -xzf krb5-1.20.1.tar.gz \
-        \
-        && cd krb5-1.20.1/src \
-        \
-        && ./configure \
-        \
-        && make \
-        \
-        && make install \
         \
         && rm -rf /var/lib/apt/lists/*
 

--- a/mldatafind/authenticate.py
+++ b/mldatafind/authenticate.py
@@ -73,7 +73,15 @@ def kinit():
 
     response = subprocess.run(args, capture_output=True, text=True)
     if response.returncode:
+        # first check to see if we recognize any of the issues
         _check_kinit_errs(response.stderr, user, keytab_location)
+
+        # if not, raise a generic error with kinit's full stderr
+        raise RuntimeError(
+            "kinit command failed with return code {}: {}".format(
+                response.returncode, response.stderr
+            )
+        )
 
 
 def make_cert(cert_path: str) -> None:

--- a/mldatafind/authenticate.py
+++ b/mldatafind/authenticate.py
@@ -1,10 +1,31 @@
 import os
 import shutil
 import subprocess
-from pathlib import Path
 
 from ciecplib.ui import get_cert
 from ciecplib.x509 import check_cert, load_cert, write_cert
+
+_kinit_errs = {
+    "Key table file '{keytab_location}' not found": (
+        "kinit command failed because key table file "
+        "'{keytab_location}' not found. See instructions for "
+        "setting up passwordless authentication at "
+        "https://computing.docs.ligo.org/guide/auth/kerberos/#ligo"
+    ),
+    "Keytab contains no suitable keys for {user}@LIGO.ORG": (
+        "kinit command failed because key table file "
+        "was not configured for user {user}. Make sure "
+        "that when following instructions at "
+        "https://computing.docs.ligo.org/guide/auth/kerberos/#ligo "
+        "that you replace 'albert.einstein' with '{user}'."
+    ),
+    "Password incorrect while getting initial credentials": (
+        "kinit command failed because password saved to "
+        "key table file is incorrect for user {user}. Re-generate "
+        "with the correct password using the instructions at "
+        "https://computing.docs.ligo.org/guide/auth/kerberos/#ligo"
+    ),
+}
 
 
 def _validate_env(env_var: str):
@@ -23,6 +44,42 @@ def _validate_env(env_var: str):
         raise ValueError(f"{env_var} environment variable not set")
 
     return value
+
+
+def _check_kinit_errs(stderr: str, user: str, keytab_location: str) -> None:
+    for key, msg in _kinit_errs.items():
+        key = key.format(user=user, keytab_location=keytab_location)
+        if stderr.startswith("kinit: " + key):
+            msg = msg.format(user=user, keytab_location=keytab_location)
+            raise OSError(msg)
+
+
+def kinit():
+    user = _validate_env("LIGO_USERNAME")
+    keytab_location = _validate_env("KRB5_KTNAME")
+
+    kinit_command = shutil.which("kinit")
+    if kinit_command is None:
+        raise ValueError("kinit command not found")
+
+    args = [
+        kinit_command,
+        "-p",
+        f"{user}@LIGO.ORG",
+        "-k",
+        "-t",
+        keytab_location,
+    ]
+
+    response = subprocess.run(args, capture_output=True, text=True)
+    if response.returncode:
+        _check_kinit_errs(response.stderr, user, keytab_location)
+
+
+def make_cert(cert_path: str) -> None:
+    kinit()
+    cert, key = get_cert(kerberos=True)
+    write_cert(cert_path, cert, key)
 
 
 def authenticate():
@@ -46,38 +103,14 @@ def authenticate():
 
     """
 
-    user = _validate_env("LIGO_USERNAME")
-    keytab_location = _validate_env("KRB5_KTNAME")
-    path = _validate_env("X509_USER_PROXY")
-
-    kinit_command = shutil.which("kinit")
-    if kinit_command is None:
-        raise ValueError("kinit command not found")
-
-    args = [
-        kinit_command,
-        "-p",
-        f"{user}@LIGO.ORG",
-        "-k",
-        "-t",
-        keytab_location,
-    ]
-    subprocess.run(args, check=True)
-
-    path = os.getenv("X509_USER_PROXY")
-
-    if path is None:
-        raise ValueError("X509_USER_PROXY environment variable not set")
-
-    elif Path(path).exists():
-        cert = load_cert(path)
+    cert_path = _validate_env("X509_USER_PROXY")
+    if os.path.exists(cert_path):
+        cert = load_cert(cert_path)
         try:
             check_cert(cert)
         except RuntimeError:
-            cert, key = get_cert(kerberos=True)
-            write_cert(path, cert, key)
+            make_cert(cert_path)
     else:
-        cert, key = get_cert(kerberos=True)
-        write_cert(path, cert, key)
+        make_cert(cert_path)
 
-    return path
+    return cert_path

--- a/mldatafind/segments.py
+++ b/mldatafind/segments.py
@@ -54,7 +54,7 @@ def query_segments(
         )
 
     segments = segments.intersection().active
-    if min_duration is not None:
+    if min_duration > 0:
         segments = filter(lambda i: i[1] - i[0] >= min_duration, segments)
         segments = SegmentList(segments)
     return segments


### PR DESCRIPTION
Adding a `Dockerfile` to containerize `mldatafind`. While I suspect this may have some limited utility, the main hope is that it will serve as a template for containerized deployments of applications that depend on `mldatafind` by making explicit the environment variables and default volumes it expects. This will also serve as a base to start building out cloud-based examples of the ML4GW ecosystem.
- [x] Add container build to workflow for pushes to `main` after unit tests pass