### PR TITLE
move gwpy installation to pypi

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -3,6 +3,5 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - gwpy
   - python-ldas-tools-framecpp
   - python-nds2-client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
+gwpy = "^2.1"
+astropy = "<5.0.0" 
 scipy = "<1.8"
 numpy = ">=1.22.0,<1.22.4"
 ciecplib = "^0.7.1"


### PR DESCRIPTION
Move `gwpy` installation from conda to poetry so users installing mldatafind for reading/writing h5 files (e.g. in the BBHnet train project) don't need to additionally install gwpy. Restrict to <3.0 and include astropy restriction to <5.0.