### PR TITLE
`io.read_timeseries` improvements

### DIFF
--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -145,6 +145,7 @@ def read_timeseries(
     t0: Optional[float] = None,
     tf: Optional[float] = None,
     array_like: bool = False,
+    strict: bool = False,
     **kwargs,
 ) -> Union[TimeSeriesDict, Tuple[np.ndarray, np.ndarray]]:
     """
@@ -177,7 +178,8 @@ def read_timeseries(
     # downselect to files containing requested range,
     # following the file naming convention {prefix}-{start}-{duration}
     # if none exist, try to read anyway
-    paths = filter_and_sort_files(path, t0, tf) or path
+    filtered = filter_and_sort_files(path, t0, tf)
+    paths = filtered if strict else filtered or path
 
     # this call will raise error if
     # channel doesn't exist,

--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -145,6 +145,7 @@ def read_timeseries(
     t0: Optional[float] = None,
     tf: Optional[float] = None,
     array_like: bool = False,
+    **kwargs,
 ) -> Union[TimeSeriesDict, Tuple[np.ndarray, np.ndarray]]:
     """
     Read multiple channel timeseries from hdf5 or gwf
@@ -168,18 +169,21 @@ def read_timeseries(
         array_like:
             Return in array like format.
             Otherwise, return gwpy.TimeSeriesDict
-
+        **kwargs
+            Additional kwargs to be passed to TimeSeriesDict.read
     Returns gwpy.TimeSeriesDict or Tuple of np.ndarrays
     """
 
-    # downselect to files containing requested range
-    paths = filter_and_sort_files(path, t0, tf)
+    # downselect to files containing requested range,
+    # following the file naming convention {prefix}-{start}-{duration}
+    # if none exist, try to read anyway
+    paths = filter_and_sort_files(path, t0, tf) or path
 
     # this call will raise error if
     # channel doesn't exist,
     # if any channel doesnt contain
     # data from t0 to tf, or if gaps exist
-    ts_dict = TimeSeriesDict.read(paths, channels, start=t0, end=tf)
+    ts_dict = TimeSeriesDict.read(paths, channels, start=t0, end=tf, **kwargs)
 
     if not array_like:
         return ts_dict

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -210,4 +210,16 @@ def test_read_timeseries(
     ).all()
     assert data.shape == (len(channel_names), sample_rate * (file_length - 1))
 
+    # test reading file path that doesn't subscribe to
+    # our naming conventions
+    path = write_dir / "timeseries.hdf5"
+    ts_dict = TimeSeriesDict()
+    times = np.arange(t0, t0 + 1000, 1 / sample_rate)
+    for i, channel in enumerate(channel_names):
+        data = np.arange(len(times)) * i
+        ts_dict[channel] = TimeSeries(data=data, times=times)
+    ts_dict.write(path)
+
+    data, times = io.read_timeseries(path, channel_names, array_like=True)
+
     # TODO: test when array_like is False


### PR DESCRIPTION
1. Allow `read_timeseries` to read files that don't follow naming convention
2. Forward `**kwargs` to `TimeSeriesDict.read()`
closes #27 
3. Adds strict kwarg to enforce naming convention

- [ ] Tests for strict kwarg

