### PR TITLE
Open data enhancements

### DIFF
--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -243,11 +243,10 @@ def fetch_timeseries(
     Returns gwpy.TimeSeriesDict or Tuple of np.ndarrays
     """
 
-    # Channels that are interferometer names should query open data
-    open_data_channels = []
-    for i, chan in enumerate(channels):
-        if chan in OPEN_DATA_CHANNELS:
-            open_data_channels.append(channels.pop(i))
+    open_data_channels = list(
+        filter(lambda x: x in OPEN_DATA_CHANNELS, channels)
+    )
+    channels = list(filter(lambda x: x not in OPEN_DATA_CHANNELS, channels))
 
     # fetch data from nds2
     ts_dict = TimeSeriesDict.get(

--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -243,12 +243,12 @@ def fetch_timeseries(
         channels, start=start, end=end, nproc=nproc, verbose=True
     )
 
+    # fetch open data channels and combine
     if open_data_channels:
-        # fetch open data channels and combine
         open_data_ts_dict = _fetch_open_data(
             open_data_channels, start=start, end=end, nproc=nproc, verbose=True
         )
-        ts_dict.append(open_data_ts_dict)
+        ts_dict.update(open_data_ts_dict)
 
     if not array_like:
         return ts_dict

--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -270,7 +270,6 @@ def fetch_timeseries(
         )
         ts_dict.update(open_data_ts_dict)
 
-    print(ts_dict)
     if not array_like:
         return ts_dict
 

--- a/mldatafind/io.py
+++ b/mldatafind/io.py
@@ -249,13 +249,15 @@ def fetch_timeseries(
     channels = list(filter(lambda x: x not in OPEN_DATA_CHANNELS, channels))
 
     # fetch data from nds2
-    ts_dict = TimeSeriesDict.get(
-        channels,
-        start=start,
-        end=end,
-        verbose=verbose,
-        **kwargs,
-    )
+    ts_dict = TimeSeriesDict()
+    if channels:
+        ts_dict = TimeSeriesDict.get(
+            channels,
+            start=start,
+            end=end,
+            verbose=verbose,
+            **kwargs,
+        )
 
     # fetch open data channels and combine
     if open_data_channels:
@@ -268,6 +270,7 @@ def fetch_timeseries(
         )
         ts_dict.update(open_data_ts_dict)
 
+    print(ts_dict)
     if not array_like:
         return ts_dict
 

--- a/mldatafind/segments.py
+++ b/mldatafind/segments.py
@@ -47,10 +47,8 @@ def query_segments(
         )
 
     # split open data flags from private flags
-    open_data_flags = []
-    for i, flag in enumerate(flags):
-        if flag in OPEN_DATA_FLAGS:
-            open_data_flags.append(flags.pop(i))
+    open_data_flags = list(filter(lambda x: x in OPEN_DATA_FLAGS, flags))
+    flags = list(filter(lambda x: x not in OPEN_DATA_FLAGS, flags))
 
     try:
         segments = DataQualityDict.query_dqsegdb(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -216,7 +216,7 @@ def test_read_timeseries(
 
 def test_fetch_timeseries():
     CHANNELS = ["H1:STRAIN", "L1:STRAIN"]
-    OPEN_CHANNELS = ["V1"]
+    OPEN_CHANNELS = ["V1", "H1"]
 
     ts = TimeSeries([0, 1], times=[0, 1])
     ts_dict = TimeSeriesDict({channel: ts for channel in CHANNELS})

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from gwpy.segments import (
@@ -23,14 +23,16 @@ def test_query_segments():
         ]
     )
     flags = [i + "1:ANALYSIS" for i in "HL"]
+    open_flags = ["H1_DATA", "L1_DATA"]
 
     segments = DataQualityDict(
         {flag: DataQualityFlag(active=segment_list) for flag in flags}
     )
+
     with patch(
         "mldatafind.segments.DataQualityDict.query_dqsegdb",
         return_value=segments,
-    ):
+    ) as mock_query:
         # technically the times don't matter since nothing
         # is actually getting queried but for clarity's sake
         intersection = query_segments(flags, 0, 1200)
@@ -44,9 +46,27 @@ def test_query_segments():
         intersection = query_segments(flags, 0, 1200, min_duration=110)
         assert intersection == SegmentList([Segment([0, 200])])
 
+        with patch(
+            "mldatafind.segments.DataQualityFlag.fetch_open_data",
+            return_value=DataQualityFlag(active=segment_list),
+        ) as mock_fetch:
+            intersection = query_segments(
+                flags + open_flags, 0, 1200, min_duration=110
+            )
+
+            assert intersection == SegmentList([Segment([0, 200])])
+            mock_fetch.assert_has_calls(
+                [call(flag, 0, 1200) for flag in open_flags]
+            )
+
+            # called 3 times above
+            mock_query.assert_has_calls([call(flags, 0, 1200)] * 3)
+
     # now shift segments so that
     # there is no overlap
+
     for i, flag in enumerate(segments.values()):
+
         flag.active = segment_list.shift(i * 300)
 
     with patch(


### PR DESCRIPTION
1. Makes API more gwpy-like (e.g `t0` -> `start`, `tf` -> `end`)
2. If an IFO name is passed as a channel to `fetch_timeseries`, will query open data
3. If a specific open data flag is passed to `query_segments` will query open data (see [here](https://www.gw-openscience.org/timeline/)). 
