### PR TITLE
set `job_file_dir` for each workflows job file factory

### DIFF
--- a/mldatafind/law/tasks/condor/base.py
+++ b/mldatafind/law/tasks/condor/base.py
@@ -47,7 +47,6 @@ class LDGCondorWorkflow(htcondor.HTCondorWorkflow):
         law.config.update(
             {
                 "job": {
-                    "job_file_dir": self.job_file_dir,
                     "job_file_dir_cleanup": "False",
                     "job_file_dir_mkdtemp": "False",
                 }
@@ -65,6 +64,11 @@ class LDGCondorWorkflow(htcondor.HTCondorWorkflow):
     @property
     def job_file_dir(self):
         return self.htcondor_output_directory().child("jobs", type="d").path
+    
+    def htcondor_create_job_file_factory(self, **kwargs):
+        # set the job file dir to proper location
+        kwargs["dir"] = self.job_file_dir
+        return super().htcondor_create_job_file_factory(**kwargs)
 
     @property
     def law_config(self):

--- a/mldatafind/law/tasks/condor/base.py
+++ b/mldatafind/law/tasks/condor/base.py
@@ -64,7 +64,7 @@ class LDGCondorWorkflow(htcondor.HTCondorWorkflow):
     @property
     def job_file_dir(self):
         return self.htcondor_output_directory().child("jobs", type="d").path
-    
+
     def htcondor_create_job_file_factory(self, **kwargs):
         # set the job file dir to proper location
         kwargs["dir"] = self.job_file_dir


### PR DESCRIPTION
Sets a unique directory for each condor workflows job file factory so there aren't any overwrites